### PR TITLE
Fixed SoftwareSerial library path

### DIFF
--- a/src/DynamixelInterface.cpp
+++ b/src/DynamixelInterface.cpp
@@ -1,6 +1,6 @@
 
 #include "DynamixelInterface.h"
-#include <../../libraries/SoftwareSerial/SoftwareSerial.h>
+#include <SoftwareSerial.h>
 
 DynamixelInterface *createSerialInterface(HardwareSerial &aSerial)
 {


### PR DESCRIPTION
Thank you for that library.

But in order to make it works out of the box, the path for the `SoftwareSerial` library should not be relative. In standard Arduino installation, the library is not in the user library folder but the one provided with the Arduino software.