### PR TITLE
Allow the use of the Arduino Leonardo

### DIFF
--- a/src/DynamixelInterface.cpp
+++ b/src/DynamixelInterface.cpp
@@ -2,6 +2,13 @@
 #include "DynamixelInterface.h"
 #include <../../libraries/SoftwareSerial/SoftwareSerial.h>
 
+// Some devices have uart1 but no uart0 (leonardo)
+#if !defined(TXEN0) && defined(TXEN1)
+#define TXEN0 TXEN1
+#define RXEN0 RXEN1
+#define RXCIE0 RXCIE1
+#endif
+
 DynamixelInterface *createSerialInterface(HardwareSerial &aSerial)
 {
 	return new DynamixelInterfaceImpl<HardwareSerial>(aSerial);

--- a/src/DynamixelInterface.cpp
+++ b/src/DynamixelInterface.cpp
@@ -71,6 +71,7 @@ void setWriteMode<HardwareSerial>(HardwareSerial &aStream)
 {
 	HardwareSerialAccess &stream=reinterpret_cast<HardwareSerialAccess&>(aStream);
 	*(stream.ucsrb()) &= !_BV(RXEN0);
+	*(stream.ucsrb()) &= !_BV(RXCIE0);
 	*(stream.ucsrb()) |= _BV(TXEN0);
 }
 


### PR DESCRIPTION
The Arduino Leonardo (`atmega32u4`) does not have an UART0 but only UART1.
I have used the same syntax has the official [Arduino IDE](https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/cores/arduino/HardwareSerial_private.h#L52).

Another solution is to change it inside the method like [here](https://github.com/7Robot/Eurobot-2012/blob/master/Arduino/libraries/ax12/ax12.cpp#L19)