### PR TITLE
Add a method to read the current position

### DIFF
--- a/src/DynamixelMotor.cpp
+++ b/src/DynamixelMotor.cpp
@@ -39,3 +39,10 @@ void DynamixelMotor::led(uint8_t aState)
 	write(DYN_ADDRESS_LED, aState);
 }
 
+uint16_t DynamixelMotor::currentPosition()
+{
+	uint16_t currentPosition;
+	read(DYN_ADDRESS_CURRENT_POSITION, currentPosition);
+	return currentPosition;
+}
+

--- a/src/DynamixelMotor.h
+++ b/src/DynamixelMotor.h
@@ -28,6 +28,8 @@ enum DynMotorAddress
 	DYN_ADDRESS_GOAL_POSITION		=0x1E,
 	/** \brief Goal speed, uint16_t , writable */
 	DYN_ADDRESS_GOAL_SPEED		=0x20,
+	/** \brief Current position, uint16_t , readable */
+	DYN_ADDRESS_CURRENT_POSITION		=0x24,
 };
 
 class DynamixelMotor:public DynamixelDevice
@@ -44,6 +46,8 @@ class DynamixelMotor:public DynamixelDevice
 	void position(uint16_t aPosition);
 	
 	void led(uint8_t aState);
+
+	uint16_t currentPosition();
 };
 
 #endif


### PR DESCRIPTION
I can understand that you want to keep the high-level API small to keep compatibility with the different Dynamixel models but a method to read the current position should be useful.