### PR TITLE
The recievePacket method was not checking the data read, which can lead to memory corruption.

### DIFF
--- a/src/DynamixelInterface.cpp
+++ b/src/DynamixelInterface.cpp
@@ -1,12 +1,12 @@
 
 #include "DynamixelInterface.h"
 
-void DynamixelInterface::transaction(bool aExpectStatus)
+void DynamixelInterface::transaction(bool aExpectStatus, uint8_t answerSize)
 {
 	sendPacket(mPacket);
 	if(aExpectStatus)
 	{
-		receivePacket(mPacket);
+		receivePacket(mPacket, answerSize);
 	}
 	else
 	{

--- a/src/DynamixelInterface.cpp
+++ b/src/DynamixelInterface.cpp
@@ -17,21 +17,21 @@ void DynamixelInterface::transaction(bool aExpectStatus, uint8_t answerSize)
 DynamixelStatus DynamixelInterface::read(uint8_t aID, uint8_t aAddress, uint8_t aSize, uint8_t *aPtr, uint8_t aStatusReturnLevel)
 {
 	mPacket=DynamixelPacket(aID, DYN_READ, 4, aPtr, aAddress, aSize);
-	transaction(aStatusReturnLevel>0 && aID!=BROADCAST_ID);
+	transaction(aStatusReturnLevel>0 && aID!=BROADCAST_ID, aSize);
 	return mPacket.mStatus;
 }
 
 DynamixelStatus DynamixelInterface::write(uint8_t aID, uint8_t aAddress, uint8_t aSize, const uint8_t *aPtr, uint8_t aStatusReturnLevel)
 {
 	mPacket=DynamixelPacket(aID, DYN_WRITE, aSize+3, aPtr, aAddress);
-	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID);
+	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID, aSize);
 	return mPacket.mStatus;
 }
 
 DynamixelStatus DynamixelInterface::regWrite(uint8_t aID, uint8_t aAddress, uint8_t aSize, const uint8_t *aPtr, uint8_t aStatusReturnLevel)
 {
 	mPacket=DynamixelPacket(aID, DYN_REG_WRITE, aSize+3, aPtr, aAddress);
-	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID);
+	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID, aSize);
 	return mPacket.mStatus;
 }
 

--- a/src/DynamixelInterface.cpp
+++ b/src/DynamixelInterface.cpp
@@ -24,14 +24,14 @@ DynamixelStatus DynamixelInterface::read(uint8_t aID, uint8_t aAddress, uint8_t 
 DynamixelStatus DynamixelInterface::write(uint8_t aID, uint8_t aAddress, uint8_t aSize, const uint8_t *aPtr, uint8_t aStatusReturnLevel)
 {
 	mPacket=DynamixelPacket(aID, DYN_WRITE, aSize+3, aPtr, aAddress);
-	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID, aSize);
+	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID);
 	return mPacket.mStatus;
 }
 
 DynamixelStatus DynamixelInterface::regWrite(uint8_t aID, uint8_t aAddress, uint8_t aSize, const uint8_t *aPtr, uint8_t aStatusReturnLevel)
 {
 	mPacket=DynamixelPacket(aID, DYN_REG_WRITE, aSize+3, aPtr, aAddress);
-	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID, aSize);
+	transaction(aStatusReturnLevel>1 && aID!=BROADCAST_ID);
 	return mPacket.mStatus;
 }
 

--- a/src/DynamixelInterface.h
+++ b/src/DynamixelInterface.h
@@ -14,10 +14,10 @@ class DynamixelInterface
 	public:
 	virtual void begin(unsigned long aBaud)=0;
 	virtual void sendPacket(const DynamixelPacket &aPacket)=0;
-	virtual void receivePacket(DynamixelPacket &aPacket)=0;
+	virtual void receivePacket(DynamixelPacket &aPacket, uint8_t answerSize = 0)=0;
 	virtual void end()=0;
 	
-	void transaction(bool aExpectStatus);
+	void transaction(bool aExpectStatus, uint8_t answerSize = 0);
 	
 	//sizeof(T) must be lower than DYN_INTERNAL_BUFFER_SIZE, and in any case lower than 256
 	template<class T>

--- a/src/DynamixelInterfaceArduinoImpl.cpp
+++ b/src/DynamixelInterfaceArduinoImpl.cpp
@@ -106,7 +106,6 @@ void DynamixelInterfaceImpl<T>::sendPacket(const DynamixelPacket &aPacket)
 	}
 	mStream.write(aPacket.mCheckSum);
 	mStream.flush();
-	mStream.clear();
 	readMode();
 }
 

--- a/src/DynamixelInterfaceArduinoImpl.cpp
+++ b/src/DynamixelInterfaceArduinoImpl.cpp
@@ -110,7 +110,7 @@ void DynamixelInterfaceImpl<T>::sendPacket(const DynamixelPacket &aPacket)
 }
 
 template<class T>
-void DynamixelInterfaceImpl<T>::receivePacket(DynamixelPacket &aPacket)
+void DynamixelInterfaceImpl<T>::receivePacket(DynamixelPacket &aPacket, uint8_t answerSize)
 {
 	static uint8_t buffer[3];
 	aPacket.mIDListSize = 0;
@@ -131,8 +131,13 @@ void DynamixelInterfaceImpl<T>::receivePacket(DynamixelPacket &aPacket)
 		aPacket.mStatus = DYN_STATUS_COM_ERROR | DYN_STATUS_TIMEOUT;
 		return;
 	}
-	aPacket.mID = buffer[0];
-	if (aPacket.mLength != buffer[1])
+	if (aPacket.mID != buffer[0])
+	{
+		aPacket.mStatus = DYN_STATUS_COM_ERROR;
+		return;
+	}
+	aPacket.mLength = buffer[1];
+	if (aPacket.mLength > 2 && aPacket.mLength - 2 > answerSize)
 	{
 		aPacket.mStatus = DYN_STATUS_COM_ERROR;
 		return;

--- a/src/DynamixelInterfaceArduinoImpl.cpp
+++ b/src/DynamixelInterfaceArduinoImpl.cpp
@@ -137,7 +137,7 @@ void DynamixelInterfaceImpl<T>::receivePacket(DynamixelPacket &aPacket, uint8_t 
 		return;
 	}
 	aPacket.mLength = buffer[1];
-	if (aPacket.mLength > 2 && aPacket.mLength - 2 > answerSize)
+	if (aPacket.mLength > 2 && aPacket.mLength - 2 != answerSize)
 	{
 		aPacket.mStatus = DYN_STATUS_COM_ERROR;
 		return;

--- a/src/DynamixelInterfaceArduinoImpl.h
+++ b/src/DynamixelInterfaceArduinoImpl.h
@@ -50,11 +50,12 @@ class DynamixelInterfaceImpl:public DynamixelInterface
 	/**
 	 * \brief Receive a packet on bus
 	 * \param[out] aPacket : Received packet. mData field must be previously allocated
+	 * \param[in] answerSize : the size of the memory allocated to the mData field
 	 *
 	 * The function wait for a new packet on the bus. Timeout depends of timeout of the underlying stream.
 	 * Return error code in case of communication error (timeout, checksum error, ...)
 	*/
-	void receivePacket(DynamixelPacket &aPacket);
+	void receivePacket(DynamixelPacket &aPacket, uint8_t answerSize = 0);
 
 	/**
          * \brief Stop interface


### PR DESCRIPTION
In the DynamixelInterface::receivePacket method defined in DynamixelInterfaceArduinoImpl.cpp
There was no check verifying that the two first bytes read are 0xFF
The line 130 :  aPacket.mLength=buffer[1];
was particularly dangerous because in case of communication error "buffer[1]" can contain a value higher than the number of bytes actually allocated for the received data. It can lead to memory corruption, which will create issues very hard to debug.
I replaced this line with a check (verifying that the received length is equal to the allocated space).

I also added the line 
mStream.clear();
at the end of the writing process, just before passing in reading mode, in order to clear the reception buffer before listening. Otherwise, if you have once a communication error, it will let unread bytes in the reception buffer and then the next reading will also fail, and so on.