### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A library to control dynamixel motors
 paragraph=This library allows you to control the Robotis servo motors that use a custom half-duplex serial protocol. You can control TTL models directly from Arduino, without any additional hardware, using hardware or software UART. Communication speed up to 1 MBd is supported with hardware serial. The most useful functions (speed, position, wheel/joint mode) are provided via a very simple high level interface (see test_motor example), but other operations can be done using the generic read/write functions (see test_led example).
 category=Device Control
 url=https://github.com/descampsa/ardyno
-architecture=avr
+architectures=avr


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format